### PR TITLE
Refactor tool pages with shared header and footer

### DIFF
--- a/prompt-generator/clustering.php
+++ b/prompt-generator/clustering.php
@@ -11,33 +11,10 @@
   </style>
 </head>
 <body>
-
-
-
-<nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Green Mind</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="longtail-generator.html">Add Longtails</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link active" href="keyword-structuring-tool.html">Keywords Breaker</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="clustering.html">Clustering</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="content-prompt-generator.html">Content Creation</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
+<?php
+  $active = 'clustering';
+  include 'header.php';
+?>
 
 
 <div class="container">
@@ -109,12 +86,9 @@ function copyClusteringPrompt() {
   const hiddenTextarea = document.getElementById('clipboardArea');
   hiddenTextarea.value = text;
   hiddenTextarea.select();
-  document.execCommand("copy");
-  alert("Prompt copied to clipboard!");
+document.execCommand("copy");
+alert("Prompt copied to clipboard!");
 }
 </script>
+<?php include 'footer.php'; ?>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-
-</body>
-</html>

--- a/prompt-generator/content-prompt-generator.php
+++ b/prompt-generator/content-prompt-generator.php
@@ -11,31 +11,10 @@
   </style>
 </head>
 <body>
-
-<nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Green Mind</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="longtail-generator.html">Add Longtails</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link active" href="keyword-structuring-tool.html">Keywords Breaker</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="clustering.html">Clustering</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="content-prompt-generator.html">Content Creation</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
+<?php
+  $active = 'content';
+  include 'header.php';
+?>
 
 
 <div class="container">
@@ -213,12 +192,9 @@ function copyPrompt() {
   const ta = document.getElementById('clipboardArea');
   ta.value = text;
   ta.select();
-  document.execCommand("copy");
-  alert("Prompt copied to clipboard!");
+document.execCommand("copy");
+alert("Prompt copied to clipboard!");
 }
 </script>
+<?php include 'footer.php'; ?>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-
-</body>
-</html>

--- a/prompt-generator/footer.php
+++ b/prompt-generator/footer.php
@@ -1,0 +1,4 @@
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
+</body>
+</html>

--- a/prompt-generator/header.php
+++ b/prompt-generator/header.php
@@ -1,0 +1,27 @@
+<?php
+if (!isset($active)) $active = '';
+?>
+<nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">Green Mind</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link<?php echo $active === 'longtail' ? ' active' : ''; ?>" href="longtail-generator.php">Add Longtails</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link<?php echo $active === 'keyword' ? ' active' : ''; ?>" href="keyword-structuring-tool.php">Keywords Breaker</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link<?php echo $active === 'clustering' ? ' active' : ''; ?>" href="clustering.php">Clustering</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link<?php echo $active === 'content' ? ' active' : ''; ?>" href="content-prompt-generator.php">Content Creation</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/prompt-generator/keyword-structuring-tool.php
+++ b/prompt-generator/keyword-structuring-tool.php
@@ -11,32 +11,10 @@
   </style>
 </head>
 <body>
-
-
-<nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Green Mind</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="longtail-generator.html">Add Longtails</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link active" href="keyword-structuring-tool.html">Keywords Breaker</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="clustering.html">Clustering</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="content-prompt-generator.html">Content Creation</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
+<?php
+  $active = 'keyword';
+  include 'header.php';
+?>
 
 
 <div class="container">
@@ -98,12 +76,9 @@ function copyPrompt() {
   const hiddenTextarea = document.getElementById('clipboardArea');
   hiddenTextarea.value = text;
   hiddenTextarea.select();
-  document.execCommand("copy");
-  alert("Prompt copied to clipboard!");
+document.execCommand("copy");
+alert("Prompt copied to clipboard!");
 }
 </script>
+<?php include 'footer.php'; ?>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-
-</body>
-</html>

--- a/prompt-generator/longtail-generator.php
+++ b/prompt-generator/longtail-generator.php
@@ -11,34 +11,10 @@
   </style>
 </head>
 <body>
-
-
-
-
-<nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Green Mind</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="longtail-generator.html">Add Longtails</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link active" href="keyword-structuring-tool.html">Keywords Breaker</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="clustering.html">Clustering</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="content-prompt-generator.html">Content Creation</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
+<?php
+  $active = 'longtail';
+  include 'header.php';
+?>
 
 
 
@@ -115,13 +91,8 @@ function copyLongtailPrompt() {
   hiddenTextarea.value = text;
   hiddenTextarea.select();
   document.execCommand("copy");
-  alert("Prompt copied to clipboard!");
+alert("Prompt copied to clipboard!");
 }
 </script>
+<?php include 'footer.php'; ?>
 
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-
-
-</body>
-</html>


### PR DESCRIPTION
## Summary
- add `header.php` with navigation bar
- add `footer.php` for scripts and closing tags
- convert tool pages to PHP and include the new partials
- highlight the active menu item via a page variable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9fc8f628833398835106610d1e7e