### PR TITLE
Change group name cell to text

### DIFF
--- a/seo-platform/dashboard.php
+++ b/seo-platform/dashboard.php
@@ -34,8 +34,6 @@ if (!$client) die("Client not found");
 
 <!-- Group Keywords -->
 <form method="POST" style="margin-top:20px;">
-    <label><strong>Target keywords for grouping (separated by |):</strong></label>
-    <input type="text" name="target_keywords" placeholder="keyword1|keyword2">
     <button type="submit" name="group_keywords">Group Keywords</button>
 </form>
 
@@ -158,40 +156,7 @@ if (isset($_POST['add_keywords'])) {
 
 
 if (isset($_POST['group_keywords'])) {
-    $targets = array_filter(array_map('trim', explode('|', strtolower($_POST['target_keywords'] ?? ''))));
-    $stmt = $pdo->prepare("SELECT id, keyword FROM keywords WHERE client_id = ?");
-    $stmt->execute([$client_id]);
-    $rows = $stmt->fetchAll();
-    $groups = [];
-    $map = [];
-    foreach ($rows as $r) {
-        $original = $r['keyword'];
-        $lower = strtolower($original);
-        if (in_array($lower, $targets, true)) {
-            $group = '**Parent Keyword**';
-        } else {
-            $words = array_values(array_filter(explode(' ', $lower), function($w) use ($targets) { return $w !== '' && !in_array($w, $targets, true); }));
-            if (!empty($words)) {
-                $common = $words[0];
-                if (!isset($groups[$common])) {
-                    $groups[$common] = $original;
-                }
-                $group = $groups[$common];
-            } else {
-                $group = $original;
-            }
-        }
-        $map[$r['id']] = $group;
-    }
-    $update = $pdo->prepare("UPDATE keywords SET group_name = ? WHERE id = ? AND client_id = ?");
-    foreach ($map as $id => $g) {
-        $update->execute([$g, $id, $client_id]);
-    }
-    $counts = array_count_values($map);
-    $updateCount = $pdo->prepare("UPDATE keywords SET group_count = ? WHERE id = ? AND client_id = ?");
-    foreach ($map as $id => $g) {
-        $updateCount->execute([$counts[$g], $id, $client_id]);
-    }
+    keywordClustering($pdo, $client_id);
     echo "<p class='success'>Keywords grouped successfully.</p>";
 }
 
@@ -215,6 +180,12 @@ if (isset($_POST['delete_keyword'])) {
 }
 
 ?>
+
+<!-- Filters -->
+<div style="text-align:right; margin-top:20px;">
+    <input type="text" id="keywordFilter" placeholder="Filter keywords">
+    <input type="text" id="groupFilter" placeholder="Filter groups">
+</div>
 
 <!-- Keywords Table -->
 <form method="POST">
@@ -244,7 +215,7 @@ if (isset($_POST['delete_keyword'])) {
             <td>" . $row['form'] . "</td>
             <td><input type='text' name='content_link[{$row['id']}]' value='" . htmlspecialchars($row['content_link']) . "'></td>
             <td><input type='text' name='page_type[{$row['id']}]' value='" . htmlspecialchars($row['page_type']) . "'></td>
-            <td><input type='text' name='group_name[{$row['id']}]' value='" . htmlspecialchars($row['group_name']) . "'></td>
+            <td>" . htmlspecialchars($row['group_name']) . "<input type='hidden' name='group_name[{$row['id']}]' value='" . htmlspecialchars($row['group_name']) . "'></td>
             <td><input type='number' name='group_count[{$row['id']}]' value='" . $row['group_count'] . "'></td>
             <td><input type='text' name='cluster_name[{$row['id']}]' value='" . htmlspecialchars($row['cluster_name']) . "'></td>
         </tr>";
@@ -256,5 +227,20 @@ if (isset($_POST['delete_keyword'])) {
 </form>
 
 <p><a href="index.php">&larr; Back to Clients</a></p>
+
+<script>
+function filterTable() {
+    const kw = document.getElementById('keywordFilter').value.toLowerCase();
+    const grp = document.getElementById('groupFilter').value.toLowerCase();
+    document.querySelectorAll('table tbody tr').forEach(tr => {
+        const keyword = tr.children[1].innerText.toLowerCase();
+        const group = tr.children[6].innerText.toLowerCase();
+        const show = keyword.includes(kw) && group.includes(grp);
+        tr.style.display = show ? '' : 'none';
+    });
+}
+document.getElementById('keywordFilter').addEventListener('input', filterTable);
+document.getElementById('groupFilter').addEventListener('input', filterTable);
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show group name as plain text by default
- remove manual group target input
- add keyword and group filters for quick search

## Testing
- `php -l seo-platform/dashboard.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8b172ec88333bd6c74d82d411e8d