### PR TITLE
Fix dashboard by reverting manual grouping

### DIFF
--- a/seo-platform/dashboard.php
+++ b/seo-platform/dashboard.php
@@ -32,13 +32,6 @@ if (!$client) die("Client not found");
     <button type="submit" name="add_keywords">Add Keywords</button>
 </form>
 
-<!-- Group Keywords -->
-<form method="POST" style="margin-top:20px;">
-    <label><strong>Target keywords for grouping (separated by |):</strong></label>
-    <input type="text" name="target_keywords" placeholder="keyword1|keyword2">
-    <button type="submit" name="group_keywords">Group Keywords</button>
-</form>
-
 <?php
 
 function keywordClustering(PDO $pdo, int $client_id) {
@@ -64,7 +57,42 @@ function keywordClustering(PDO $pdo, int $client_id) {
         if (count($words) >= 3) $base[] = implode(' ', array_slice($words, 0, 3));
         if (count($words) >= 2) $base[] = implode(' ', array_slice($words, 0, 2));
         return $base;
-@@ -103,214 +103,158 @@ function keywordClustering(PDO $pdo, int $client_id) {
+    };
+
+    foreach ($keywords as $kw) {
+        foreach ($getBasePhrases(strtolower($kw)) as $phrase) {
+            $phraseCount[$phrase] = ($phraseCount[$phrase] ?? 0) + 1;
+        }
+    }
+
+    $phraseGroupMap = [];
+    foreach ($phraseCount as $phrase => $count) {
+        if ($count > 1) {
+            $phraseGroupMap[$phrase] = $phrase;
+        }
+    }
+
+    $findGroup = function($keyword) use ($phraseGroupMap) {
+        $best = '';
+        $maxWords = 0;
+        $kwWords = count(explode(' ', $keyword));
+        foreach ($phraseGroupMap as $phrase => $_) {
+            $num = count(explode(' ', $phrase));
+            if ($num > $kwWords) continue;
+            if (preg_match('/(^|\s)'.preg_quote($phrase, '/').'(?=\s|$)/i', $keyword)) {
+                if ($num > $maxWords) {
+                    $best = $phrase;
+                    $maxWords = $num;
+                }
+            }
+        }
+        return $best;
+    };
+
+    $groups = [];
+    foreach ($keywords as $id => $kw) {
+        $group = $findGroup(strtolower($kw));
+        $groups[$id] = $group;
     }
 
     $counts = array_count_values($groups);
@@ -121,72 +149,12 @@ if (isset($_POST['add_keywords'])) {
     keywordClustering($pdo, $client_id);
 }
 
-
-if (isset($_POST['group_keywords'])) {
-    $targets = array_filter(array_map('trim', explode('|', strtolower($_POST['target_keywords'] ?? ''))));
-    $stmt = $pdo->prepare("SELECT id, keyword FROM keywords WHERE client_id = ?");
-    $stmt->execute([$client_id]);
-    $rows = $stmt->fetchAll();
-    $groups = [];
-    $map = [];
-    foreach ($rows as $r) {
-        $original = $r['keyword'];
-        $lower = strtolower($original);
-        if (in_array($lower, $targets, true)) {
-            $group = '**Parent Keyword**';
-        } else {
-            $words = array_values(array_filter(explode(' ', $lower), function($w) use ($targets) { return $w !== '' && !in_array($w, $targets, true); }));
-            if (!empty($words)) {
-                $common = $words[0];
-                if (!isset($groups[$common])) {
-                    $groups[$common] = $original;
-                }
-                $group = $groups[$common];
-            } else {
-                $group = $original;
-            }
-        }
-        $map[$r['id']] = $group;
-    }
-    $update = $pdo->prepare("UPDATE keywords SET group_name = ? WHERE id = ? AND client_id = ?");
-    foreach ($map as $id => $g) {
-        $update->execute([$g, $id, $client_id]);
-    }
-    $counts = array_count_values($map);
-    $updateCount = $pdo->prepare("UPDATE keywords SET group_count = ? WHERE id = ? AND client_id = ?");
-    foreach ($map as $id => $g) {
-        $updateCount->execute([$counts[$g], $id, $client_id]);
-    }
-    echo "<p class='success'>Keywords grouped successfully.</p>";
-}
-
-if (isset($_POST['update_keywords']) && isset($_POST['ids'])) {
-    $update = $pdo->prepare("UPDATE keywords SET content_link = ?, page_type = ?, group_name = ?, group_count = ?, cluster_name = ? WHERE id = ? AND client_id = ?");
-    foreach ($_POST['ids'] as $id) {
-        $link = trim($_POST['content_link'][$id] ?? '');
-        $pageType = trim($_POST['page_type'][$id] ?? '');
-        $groupName = trim($_POST['group_name'][$id] ?? '');
-        $groupCount = isset($_POST['group_count'][$id]) && is_numeric($_POST['group_count'][$id]) ? (int)$_POST['group_count'][$id] : 0;
-        $clusterName = trim($_POST['cluster_name'][$id] ?? '');
-        $update->execute([$link, $pageType, $groupName, $groupCount, $clusterName, $id, $client_id]);
-    }
-    echo "<p class='success'>Keywords updated successfully.</p>";
-}
-
-if (isset($_POST['delete_keyword'])) {
-    $del = $pdo->prepare("DELETE FROM keywords WHERE id = ? AND client_id = ?");
-    $del->execute([(int)$_POST['delete_keyword'], $client_id]);
-    echo "<p class='success'>Keyword deleted.</p>";
-}
-
 ?>
 
 <!-- Keywords Table -->
-<form method="POST">
 <table>
     <thead>
         <tr>
-            <th>-</th>
             <th>Keyword</th>
             <th>Volume</th>
             <th>Form</th>
@@ -203,22 +171,19 @@ if (isset($_POST['delete_keyword'])) {
     $stmt->execute([$client_id]);
     foreach ($stmt as $row) {
         echo "<tr>
-            <td><button type='submit' name='delete_keyword' value='{$row['id']}'>-</button></td>
-            <td>" . htmlspecialchars($row['keyword']) . "<input type='hidden' name='ids[]' value='{$row['id']}'></td>
+            <td>" . htmlspecialchars($row['keyword']) . "</td>
             <td>" . $row['volume'] . "</td>
             <td>" . $row['form'] . "</td>
-            <td><input type='text' name='content_link[{$row['id']}]' value='" . htmlspecialchars($row['content_link']) . "'></td>
-            <td><input type='text' name='page_type[{$row['id']}]' value='" . htmlspecialchars($row['page_type']) . "'></td>
-            <td><input type='text' name='group_name[{$row['id']}]' value='" . htmlspecialchars($row['group_name']) . "'></td>
-            <td><input type='number' name='group_count[{$row['id']}]' value='" . $row['group_count'] . "'></td>
-            <td><input type='text' name='cluster_name[{$row['id']}]' value='" . htmlspecialchars($row['cluster_name']) . "'></td>
+            <td><a href='" . htmlspecialchars($row['content_link']) . "' target='_blank'>Link</a></td>
+            <td>" . htmlspecialchars($row['page_type']) . "</td>
+            <td>" . htmlspecialchars($row['group_name']) . "</td>
+            <td>" . $row['group_count'] . "</td>
+            <td>" . htmlspecialchars($row['cluster_name']) . "</td>
         </tr>";
     }
     ?>
     </tbody>
 </table>
-<button type="submit" name="update_keywords">Update</button>
-</form>
 
 <p><a href="index.php">&larr; Back to Clients</a></p>
 </body>


### PR DESCRIPTION
## Summary
- revert manual grouping functionality
- keep automatic clustering when adding keywords
- simplify dashboard table

## Testing
- `php -l seo-platform/dashboard.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e9d2b75f08333aa90ab6a9f5b60b8