### PR TITLE
Refine SEO tool navigation and keyword import

### DIFF
--- a/seo-platform/header.php
+++ b/seo-platform/header.php
@@ -23,13 +23,8 @@ $title = $title ?? 'SEO Platform';
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav">
         <?php
-        $navFiles = glob('*.php');
-        foreach ($navFiles as $navFile) {
-          if (in_array(basename($navFile), ['index.php', 'header.php', 'footer.php', 'config.php'])) continue;
-          $navTitle = ucwords(str_replace('-', ' ', pathinfo($navFile, PATHINFO_FILENAME)));
-          $active = basename($_SERVER['PHP_SELF']) === basename($navFile) ? 'active' : '';
-          echo "<li class='nav-item'><a class='nav-link $active' href='$navFile'>$navTitle</a></li>";
-        }
+          $active = basename($_SERVER['PHP_SELF']) === 'index.php' ? 'active' : '';
+          echo "<li class='nav-item'><a class='nav-link $active' href='index.php'>Clients</a></li>";
         ?>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- simplify SEO platform navbar to only show the **Clients** link
- support bulk keyword import with volume and form columns

## Testing
- `php -l seo-platform/header.php` *(fails: php command not found)*
- `php -l seo-platform/dashboard.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea3136f4c833391e78d15719abaf2