### PR TITLE
Enhance dashboard usability with sticky controls

### DIFF
--- a/seo-platform/dashboard.php
+++ b/seo-platform/dashboard.php
@@ -181,7 +181,7 @@ $stmt->execute([$client_id]);
 ?>
 
 <form method="POST" id="updateForm">
-  <div class="d-flex justify-content-between mb-2">
+  <div class="d-flex justify-content-between mb-2 sticky-controls">
     <button type="submit" name="update_keywords" class="btn btn-success">Update</button>
     <div class="d-flex">
       <select id="filterField" class="form-select form-select-sm me-2" style="width:auto;">

--- a/seo-platform/header.php
+++ b/seo-platform/header.php
@@ -11,6 +11,13 @@ $title = $title ?? 'SEO Platform';
   <style>
     body { padding: 30px; margin-top: 50px; }
     img.logo { width: 50px; margin-right: 10px; }
+    .sticky-controls {
+      position: sticky;
+      top: 70px;
+      z-index: 100;
+      background-color: #fff;
+      padding: 8px 0;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- create `.sticky-controls` utility class
- keep dashboard update controls fixed while scrolling

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1f1197ec833383c53cf3e75473f7