### PR TITLE
Improve dashboard UX with live updates

### DIFF
--- a/seo-platform/dashboard.php
+++ b/seo-platform/dashboard.php
@@ -14,6 +14,7 @@ include 'header.php';
 ?>
 
 <h5 class="mb-3"><?= htmlspecialchars($client['name']) ?> – Keywords</h5>
+<div id="notice" class="alert alert-success position-fixed top-0 end-0 mt-4 me-3" style="display:none; z-index:2000;"></div>
 
 <!-- Add Keyword Form -->
 <form method="POST" class="mb-4">
@@ -246,7 +247,7 @@ foreach ($stmt as $row) {
     }
 
     echo "<tr data-id='{$row['id']}'>
-        <td class='text-center'><button type='button' class='btn btn-sm btn-outline-danger remove-row'>-</button><input type='hidden' name='delete[{$row['id']}]' value='0' class='delete-flag'></td>
+        <td class='text-center'><button type='button' class='btn btn-sm btn-outline-danger remove-row'>-</button></td>
         <td>" . htmlspecialchars($row['keyword']) . "</td>
         <td class='text-center' style='background-color: $volBg'>" . $volume . "</td>
         <td class='text-center' style='background-color: $formBg'>" . $form . "</td>
@@ -277,10 +278,13 @@ foreach ($stmt as $row) {
 document.addEventListener('click', function(e) {
   if (e.target.classList.contains('remove-row')) {
     const tr = e.target.closest('tr');
-    const flag = tr.querySelector('.delete-flag');
-    const marked = flag.value === '1';
-    flag.value = marked ? '0' : '1';
-    tr.classList.toggle('text-decoration-line-through', !marked);
+    const id = tr.dataset.id;
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = `delete[${id}]`;
+    input.value = '1';
+    updateForm.appendChild(input);
+    tr.remove();
   }
 });
 
@@ -290,6 +294,13 @@ const clearFilter = document.getElementById('clearFilter');
 const updateForm = document.getElementById('updateForm');
 const pagination = document.getElementById('pagination');
 const kwTableBody = document.getElementById('kwTableBody');
+const noticeBox = document.getElementById('notice');
+
+function showNotice(msg) {
+  noticeBox.textContent = msg;
+  noticeBox.style.display = 'block';
+  setTimeout(() => { noticeBox.style.display = 'none'; }, 3000);
+}
 let currentPage = <?=$page?>;
 
 function fetchRows(page = 1) {
@@ -298,7 +309,7 @@ function fetchRows(page = 1) {
   const field = filterField.value;
   const url = 'fetch_keywords.php?client_id=<?=$client_id?>&page=' + page +
               '&q=' + encodeURIComponent(q) + '&field=' + encodeURIComponent(field);
-  fetch(url)
+  return fetch(url)
     .then(r => r.json())
     .then(data => {
       kwTableBody.innerHTML = data.rows;
@@ -315,7 +326,7 @@ updateForm.addEventListener('submit', function(e) {
     method: 'POST',
     headers: {'X-Requested-With': 'XMLHttpRequest'},
     body: fd
-  }).then(r => r.json()).then(() => fetchRows(currentPage));
+  }).then(r => r.json()).then(() => fetchRows(currentPage).then(() => showNotice('Updated')));
 });
 
 clearFilter.addEventListener('click', () => {

--- a/seo-platform/fetch_keywords.php
+++ b/seo-platform/fetch_keywords.php
@@ -66,7 +66,7 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
         }
     }
     $rows .= "<tr data-id='{$row['id']}'>";
-    $rows .= "<td class='text-center'><button type='button' class='btn btn-sm btn-outline-danger remove-row'>-</button><input type='hidden' name='delete[{$row['id']}]' value='0' class='delete-flag'></td>";
+    $rows .= "<td class='text-center'><button type='button' class='btn btn-sm btn-outline-danger remove-row'>-</button></td>";
     $rows .= "<td>" . htmlspecialchars($row['keyword']) . "</td>";
     $rows .= "<td class='text-center' style='background-color: $volBg'>" . $volume . "</td>";
     $rows .= "<td class='text-center' style='background-color: $formBg'>" . $form . "</td>";


### PR DESCRIPTION
## Summary
- show a success alert when keywords are updated
- remove rows immediately when clicking `-`
- refresh table asynchronously and notify on update

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684f2671b55c83338b21a0ae95cd697e