### PR TITLE
Fix keyword list updates

### DIFF
--- a/seo-platform/fetch_keywords.php
+++ b/seo-platform/fetch_keywords.php
@@ -66,7 +66,7 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
         }
     }
     $rows .= "<tr data-id='{$row['id']}'>";
-    $rows .= "<td class='text-center'><button type='button' class='btn btn-sm btn-outline-danger remove-row'>-</button><input type='hidden' name='delete[{$row['id']}]' value='0' class='delete-flag'></td>";
+    $rows .= "<td class='text-center'><button type='button' class='btn btn-sm btn-outline-danger remove-row'>-</button></td>";
     $rows .= "<td>" . htmlspecialchars($row['keyword']) . "</td>";
     $rows .= "<td class='text-center' style='background-color: $volBg'>" . $volume . "</td>";
     $rows .= "<td class='text-center' style='background-color: $formBg'>" . $form . "</td>";


### PR DESCRIPTION
## Summary
- ensure delete buttons from fetch_keywords.php don't include hidden flags
- track deleted rows in the browser
- keep rows hidden across filters and clear flags after update

## Testing
- ❌ `php -l seo-platform/dashboard.php` *(failed: `php: command not found`)*
- ❌ `php -l seo-platform/fetch_keywords.php` *(failed: `php: command not found`)*
- ❌ `npm test` *(failed: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_684fd027e4b48333adfba1fe4645ee3b