### PR TITLE
Improve dashboard filtering

### DIFF
--- a/seo-platform/dashboard.php
+++ b/seo-platform/dashboard.php
@@ -181,6 +181,7 @@ $stmt->execute([$client_id]);
       <select id="filterField" class="form-select form-select-sm me-2" style="width:auto;">
         <option value="keyword">Keyword</option>
         <option value="group_name">Group</option>
+        <option value="group_exact">Group Exact</option>
         <option value="cluster_name">Cluster</option>
         <option value="content_link">Link</option>
       </select>
@@ -268,22 +269,33 @@ foreach ($stmt as $row) {
 <p><a href="index.php">&larr; Back to Clients</a></p>
 
 <script>
-document.addEventListener('click', function(e) {
-  if (e.target.classList.contains('remove-row')) {
-    const tr = e.target.closest('tr');
-    const flag = tr.querySelector('.delete-flag');
-    const marked = flag.value === '1';
-    flag.value = marked ? '0' : '1';
-    tr.classList.toggle('text-decoration-line-through', !marked);
-  }
-});
-
 const filterInput = document.getElementById('filterInput');
 const filterField = document.getElementById('filterField');
 const clearFilter = document.getElementById('clearFilter');
 const pagination = document.getElementById('pagination');
 const kwTableBody = document.getElementById('kwTableBody');
 let currentPage = <?=$page?>;
+
+kwTableBody.addEventListener('click', e => {
+  if (e.target.classList.contains('remove-row')) {
+    const tr = e.target.closest('tr');
+    const flag = tr.querySelector('.delete-flag');
+    const marked = flag.value === '1';
+    flag.value = marked ? '0' : '1';
+    tr.classList.toggle('text-decoration-line-through', !marked);
+    if (filterInput.value.trim() !== '') {
+      fetchRows(currentPage);
+    }
+  }
+});
+
+kwTableBody.addEventListener('change', e => {
+  if (e.target.name && e.target.name.startsWith('link[')) {
+    if (filterInput.value.trim() !== '') {
+      fetchRows(currentPage);
+    }
+  }
+});
 
 function fetchRows(page = 1) {
   currentPage = page;

--- a/seo-platform/fetch_keywords.php
+++ b/seo-platform/fetch_keywords.php
@@ -5,7 +5,7 @@ $client_id = (int)($_GET['client_id'] ?? 0);
 $search = trim($_GET['q'] ?? '');
 $field = $_GET['field'] ?? 'keyword';
 
-$allowed = ['keyword', 'group_name', 'cluster_name', 'content_link'];
+$allowed = ['keyword', 'group_name', 'cluster_name', 'content_link', 'group_exact'];
 
 if (!in_array($field, $allowed, true)) {
     $field = 'keyword';
@@ -17,8 +17,13 @@ $page = max(1, (int)($_GET['page'] ?? 1));
 $query = "SELECT * FROM keywords WHERE client_id = ?";
 $params = [$client_id];
 if ($search !== '') {
-    $query .= " AND {$field} LIKE ?";
-    $params[] = "%$search%";
+    if ($field === 'group_exact') {
+        $query .= " AND group_name = ?";
+        $params[] = $search;
+    } else {
+        $query .= " AND {$field} LIKE ?";
+        $params[] = "%$search%";
+    }
 }
 $countStmt = $pdo->prepare(str_replace('*', 'COUNT(*)', $query));
 $countStmt->execute($params);


### PR DESCRIPTION
## Summary
- add `Group Exact` filter to dashboard
- refresh filter results after removing rows or editing links
- support `group_exact` in `fetch_keywords.php`

## Testing
- `php -l seo-platform/dashboard.php`
- `php -l seo-platform/fetch_keywords.php`


------
https://chatgpt.com/codex/tasks/task_e_684fdeb213948333a592599876635f84