### PR TITLE
Add bootstrap mega menu snippet

### DIFF
--- a/code-snippets/navbar-megamenu.html
+++ b/code-snippets/navbar-megamenu.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Mega Menu Navbar</title>
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        /* Show dropdowns on hover for screens >= lg */
+        @media (min-width: 992px) {
+            .navbar .dropdown:hover > .dropdown-menu {
+                display: block;
+            }
+        }
+    </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg bg-body-tertiary">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">Brand</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="#">Home</a>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            Services
+          </a>
+          <div class="dropdown-menu p-3" style="width: 600px;">
+            <div class="row">
+              <div class="col-lg-4">
+                <a class="dropdown-item" href="#">Service 1</a>
+                <a class="dropdown-item" href="#">Service 2</a>
+                <a class="dropdown-item" href="#">Service 3</a>
+              </div>
+              <div class="col-lg-4">
+                <a class="dropdown-item" href="#">Service 4</a>
+                <a class="dropdown-item" href="#">Service 5</a>
+                <a class="dropdown-item" href="#">Service 6</a>
+              </div>
+              <div class="col-lg-4">
+                <a class="dropdown-item" href="#">Service 7</a>
+                <a class="dropdown-item" href="#">Service 8</a>
+                <a class="dropdown-item" href="#">Service 9</a>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#">About</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#">Contact</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<!-- Bootstrap JS -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new HTML snippet under `code-snippets` demonstrating a Bootstrap navbar
  - second nav item opens a 3-column dropdown on hover for desktop
  - mobile keeps default dropdown behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685954f75efc833399b947f7fc3e1cfc